### PR TITLE
[FIX] Debido al nuevo dominio: python.info.ve.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ Venezuela.
 ## Enlace a otros sitios
 
 He dejado los enoaces a sitios que están dentro de pyve pero son autónomos con
-dirección absoluta y no relativa. Ejemplo, http://pyve.github.io/empleos/ y
+dirección absoluta y no relativa. Ejemplo, http://www.python.info.ve/empleos/ y
 las páginas propias de los eventos listados.
 
 ## Github y Travis [Borrador]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ el framework de diseño web [Bootstrap](http://getbootstrap.com/) y puede ser de
 
 * Este repositorio git trata de cumplir con las reglas que propone el flujo de trabajo [git-flow](http://nvie.com/posts/a-successful-git-branching-model/).
 * Esta propuesta trata de cumplir con las reglas que propone el [versionamiento semantico](http://semver.org/lang/es/).
-* La organización del contenido está guiada por el sitio [python.org.ve](http://pyve.github.io/) actual y por lo escrito en la propuesta del [Rediseño del Sitio Web](https://github.com/pyve/pyve.github.com/wiki/Redise%C3%B1o-del-Sitio-Web).
+* La organización del contenido está guiada por el sitio [python.info.ve](http://www.python.info.ve/) actual y por lo escrito en la propuesta del [Rediseño del Sitio Web](https://github.com/pyve/pyve.github.com/wiki/Redise%C3%B1o-del-Sitio-Web).
 
 ## ¿Cómo colaborar?
 

--- a/assets/eventos/pytatuy2013/index.html
+++ b/assets/eventos/pytatuy2013/index.html
@@ -13,7 +13,7 @@
   <!-- FACEBOOK -->
   <meta property="fb:app_id" content="372862979453673">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="http://pyve.github.io/pytatuy2013">
+  <meta property="og:url" content="http://www.python.info.ve/pytatuy2013">
   <meta property="og:title" content="PyTatuy 2013">
   <meta property="og:description" content="Día Python de Mérida 2013">
   <meta property="og:image" content="themes/yellow-swan/img/badge.jpg">

--- a/content/lista-de-correos/contents.lr
+++ b/content/lista-de-correos/contents.lr
@@ -30,4 +30,4 @@ y:
 ## Acerca de las ofertas de empleo
 
 Si quieres hacer ofertas de empleo, hazlo a través de
-[nuestra aplicación de empleos](http://pyve.github.io/empleos/).
+[nuestra aplicación de empleos](http://www.python.info.ve/empleos/).

--- a/templates/404.html
+++ b/templates/404.html
@@ -35,7 +35,7 @@
                     Sorry, an error has occured, Requested page not found!
                 </div>
                 <div class="error-actions">
-                    <a href="http://pyve.github.com"
+                    <a href="/"
                         class="btn btn-primary btn-lg">
                         <span class="glyphicon glyphicon-home">
                         </span>


### PR DESCRIPTION
- Algunos url estaban rotos, por consiguiente se
- Referencian a '/' donde es posible .
- Al nuevo url python.info.ve donde es necesario.